### PR TITLE
Add support for directory-based embeddings and fold CSVs

### DIFF
--- a/bags_io.py
+++ b/bags_io.py
@@ -1,6 +1,8 @@
 # survivmil/bags_io.py
 from __future__ import annotations
 import os
+from typing import Tuple
+
 import numpy as np
 
 def _load_npy(path: str):
@@ -16,19 +18,55 @@ def _load_npy(path: str):
     return feats, coords
 
 
-def load_bag(path: str):
-    """Load a single bag from .npy or .h5/.hdf5. Returns (features, coords_or_None)."""
+def load_bag(path: str) -> Tuple[np.ndarray, np.ndarray | None]:
+    """
+    Load a bag of patch features.
+
+    Parameters
+    ----------
+    path:
+        Either a single ``.npy`` file containing all features for a patient or a
+        directory of individual patch ``.npy`` files.  In the latter case the
+        coordinates are parsed from each filename (``*_x{coord}_y{coord}.npy``).
+
+    Returns
+    -------
+    features, coords
+        ``features`` is ``(N, D)`` and ``coords`` is ``(N, 2)`` or ``None`` if
+        coordinates are unavailable.
+    """
+
+    if os.path.isdir(path):
+        feats_list, coords_list = [], []
+        for fname in sorted(os.listdir(path)):
+            if not fname.endswith(".npy"):
+                continue
+            f, c = _load_npy(os.path.join(path, fname))
+            feats_list.append(f)
+            coords_list.append(c)
+        if not feats_list:
+            raise FileNotFoundError(f"No '.npy' files found in directory '{path}'")
+        return np.stack(feats_list), np.stack(coords_list)
+
     ext = os.path.splitext(path)[1].lower()
     if ext == ".npy":
         return _load_npy(path)
     raise ValueError(f"Unsupported bag extension: {ext}")
 
 
-def resolve_bag_path(features_dir: str, bag_stem: str):
+def resolve_bag_path(features_dir: str, bag_stem: str) -> str:
     """
-    Prefer .npy; fallback to .h5/.hdf5 if present.
-    Returns absolute path or raises FileNotFoundError.
+    Locate the bag corresponding to ``bag_stem``.
+
+    The bag may either be a directory of ``.npy`` files or a single file with
+    extension ``.npy``/``.h5``/``.hdf5``.  The search order prefers directories
+    (allowing the UNI embedding layout) and then falls back to single files.
     """
+
+    dir_candidate = os.path.join(features_dir, bag_stem)
+    if os.path.isdir(dir_candidate):
+        return dir_candidate
+
     cand = [
         os.path.join(features_dir, f"{bag_stem}.npy"),
         os.path.join(features_dir, f"{bag_stem}.h5"),
@@ -37,4 +75,6 @@ def resolve_bag_path(features_dir: str, bag_stem: str):
     for p in cand:
         if os.path.exists(p):
             return p
-    raise FileNotFoundError(f"No bag found for stem='{bag_stem}' in {features_dir} (tried .npy/.h5/.hdf5).")
+    raise FileNotFoundError(
+        f"No bag found for stem='{bag_stem}' in {features_dir} (checked directory and .npy/.h5/.hdf5)."
+    )


### PR DESCRIPTION
## Summary
- allow loading a bag from a directory of UNI patch `.npy` files
- normalize `patient_id` values to match `TMA_x_y` feature folders
- enable DataModule to build train/val/test splits from fold CSV directories

## Testing
- `python -m py_compile bags_io.py dataset.py data_module.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab4b6117ec8330bb5f5a18a0b8bc60