### PR TITLE
Handle missing WSI features and enhance loader feedback

### DIFF
--- a/train_wandb.py
+++ b/train_wandb.py
@@ -2,7 +2,7 @@ import os
 import torch
 import torch.nn as nn
 import pytorch_lightning as pl
-from pytorch_lightning.callbacks import LearningRateMonitor, ModelCheckpoint
+from pytorch_lightning.callbacks import LearningRateMonitor, ModelCheckpoint, TQDMProgressBar
 from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from lightning.pytorch.loggers import WandbLogger
 import argparse
@@ -10,7 +10,6 @@ import warnings
 from data_module import histo_DataModule
 from transabmil import TransABMIL
 from pathlib import Path
-from tqdm import tqdm
 import pandas as pd
 import numpy as np
 from utils import str2bool
@@ -360,6 +359,7 @@ def train(args):
     )
     
     lr_monitor = LearningRateMonitor(logging_interval="step")
+    pb = TQDMProgressBar(refresh_rate=20)
 
     smpeds_data = histo_DataModule(
         csv_path=args.csv_dir,
@@ -395,10 +395,11 @@ def train(args):
         accelerator="gpu",
         devices=args.num_gpus,
         max_epochs=args.max_epochs,
-        callbacks=[early_stop_callback, checkpoint_callback, lr_monitor],
+        callbacks=[early_stop_callback, checkpoint_callback, lr_monitor, pb],
         default_root_dir=args.log_dir,
         logger=logger,
         num_sanity_val_steps=0,
+        log_every_n_steps=20,
     )
     trainer.fit(model, smpeds_data)
     print(f"Finished training for the prediction of patient outcome")


### PR DESCRIPTION
## Summary
- Drop patients without corresponding WSI embeddings when constructing datasets
- Expose `num_workers` for all dataloaders and announce dataset sizes after setup
- Add TQDM-based progress indicators for class-weight calculation and training

## Testing
- `python -m py_compile data_module.py dataset.py train_wandb.py`
- `python train_wandb.py --help` *(fails: No module named 'torch')*
- `pip install numpy pandas tqdm` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68ab62b549f8833088c2c4931dbcaba4