### PR TITLE
Add dataset loading completion print

### DIFF
--- a/data_module.py
+++ b/data_module.py
@@ -107,6 +107,12 @@ class histo_DataModule(pl.LightningDataModule):
                 state="test",
                 shuffle=False,
             )
+            print(
+                f"Finished loading datasets: "
+                f"{len(self.train_dset)} train / "
+                f"{len(self.val_dset)} val / "
+                f"{len(self.test_dset)} test bags"
+            )
 
     def calculate_weights(self):
         # NOTE: This assumes d[1][0] is a single-class label tensor.


### PR DESCRIPTION
## Summary
- log counts of train/val/test datasets after loading

## Testing
- `pytest -q`
- `flake8 data_module.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab69c6de888330ba296c6d24cc06ca