### PR TITLE
Expose data loader worker count

### DIFF
--- a/data_module.py
+++ b/data_module.py
@@ -132,6 +132,7 @@ class histo_DataModule(pl.LightningDataModule):
                replacement=True,
             ),
             collate_fn=collate_fn,
+            num_workers=self.args.num_workers,
         )
 
     def val_dataloader(self):
@@ -140,6 +141,7 @@ class histo_DataModule(pl.LightningDataModule):
             batch_size=self.batch_size,
             shuffle=False,
             collate_fn=collate_fn,
+            num_workers=self.args.num_workers,
         )
 
     def test_dataloader(self):
@@ -148,6 +150,7 @@ class histo_DataModule(pl.LightningDataModule):
             batch_size=self.batch_size,
             shuffle=False,
             collate_fn=collate_fn,
+            num_workers=self.args.num_workers,
         )
 
     def predict_dataloader(self):
@@ -156,5 +159,5 @@ class histo_DataModule(pl.LightningDataModule):
             batch_size=self.batch_size,
             shuffle=False,
             collate_fn=collate_fn,
-            num_workers=31,
+            num_workers=self.args.num_workers,
         )


### PR DESCRIPTION
## Summary
- allow configuring PyTorch DataLoader workers via `--num_workers`
- use provided worker count for training, validation, test, and prediction loaders

## Testing
- `python train_wandb.py --csv_dir dummy.csv --img_dir dummy --logger tensorboard --wandb_run_name test --max_epochs 1 --num_workers 32` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch torchvision --quiet` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68ab69c84e3083309584243733507ef2